### PR TITLE
Rhas feat add static check cpp

### DIFF
--- a/.github/workflows/github-actions_basic_CI.yml
+++ b/.github/workflows/github-actions_basic_CI.yml
@@ -28,7 +28,7 @@ jobs:
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: |
-          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON 
+          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 /source/
           cmake -B ${{github.workspace}}/build
 
     - uses: actions/upload-artifact@v2
@@ -45,8 +45,8 @@ jobs:
     - uses: actions/upload-artifact@v2
       if: always()
       with:
-        name: CMakeLogs_Build
-        path: ${{github.workspace}}/build/CMakeFiles/*.log
+        name: CMake_Compile_Commands
+        path: ${{github.workspace}}/compile_commands.json
 
     - name: Test
       working-directory: ${{github.workspace}}/build
@@ -68,6 +68,11 @@ jobs:
       - name : Download headers
         run : sudo apt-get install cppcheck
         if: ${{ runner.os == 'Linux' }}
+
+      - name: Download Cmake Compile Commmands JSON
+        uses: actions/download-artifact@v2
+        with:
+          name: CMake_Compile_Commands
 
       - name: Use the checker
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/github-actions_basic_CI.yml
+++ b/.github/workflows/github-actions_basic_CI.yml
@@ -28,7 +28,7 @@ jobs:
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: |
-          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ${{github.workspace}}/source/
+          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ${{github.workspace}}/
           cmake -B ${{github.workspace}}/build
 
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/github-actions_basic_CI.yml
+++ b/.github/workflows/github-actions_basic_CI.yml
@@ -1,4 +1,4 @@
-name: My First GitHub CI
+name: Static_Analyzed_Compilation
 
 on:
   push:
@@ -27,7 +27,9 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build
+      run: |
+          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON 
+          cmake -B ${{github.workspace}}/build
 
     - uses: actions/upload-artifact@v2
       if: failure()
@@ -51,3 +53,28 @@ jobs:
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}
+
+Static_Analysis :
+  # Using CPP Check on Linux (will have to tinker for Windows)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name : Download headers
+      run : sudo apt-get install cppcheck
+      if: ${{ runner.os == 'Linux' }}
+
+    - name: Use the checker
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cppcheck --output-file=static_check.txt --project=compile_commands.json
+
+    - uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: Static_Check_Output
+        path: ${{github.workspace}}/static_check.txt

--- a/.github/workflows/github-actions_basic_CI.yml
+++ b/.github/workflows/github-actions_basic_CI.yml
@@ -7,7 +7,7 @@ on:
     branches: [ $default-branch ]
 
 jobs:
-  Setup_CMake :
+  Setup_CMake_and_Compile :
   # The CMake configure and build commands are platform agnostic and should work equally
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
@@ -56,6 +56,7 @@ jobs:
 
   Static_Analysis :
     # Using CPP Check on Linux (will have to tinker for Windows)
+      needs: Setup_CMake_and_Compile
       runs-on: ${{ matrix.os }}
       strategy:
         fail-fast: false

--- a/.github/workflows/github-actions_basic_CI.yml
+++ b/.github/workflows/github-actions_basic_CI.yml
@@ -54,27 +54,27 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -C ${{env.BUILD_TYPE}}
 
-Static_Analysis :
-  # Using CPP Check on Linux (will have to tinker for Windows)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-    steps:
-    - uses: actions/checkout@v2
-    
-    - name : Download headers
-      run : sudo apt-get install cppcheck
-      if: ${{ runner.os == 'Linux' }}
+  Static_Analysis :
+    # Using CPP Check on Linux (will have to tinker for Windows)
+      runs-on: ${{ matrix.os }}
+      strategy:
+        fail-fast: false
+        matrix:
+          os: [ubuntu-latest]
+      steps:
+      - uses: actions/checkout@v2
+      
+      - name : Download headers
+        run : sudo apt-get install cppcheck
+        if: ${{ runner.os == 'Linux' }}
 
-    - name: Use the checker
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cppcheck --output-file=static_check.txt --project=compile_commands.json
+      - name: Use the checker
+        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+        run: cppcheck --output-file=static_check.txt --project=compile_commands.json
 
-    - uses: actions/upload-artifact@v2
-      if: always()
-      with:
-        name: Static_Check_Output
-        path: ${{github.workspace}}/static_check.txt
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: Static_Check_Output
+          path: ${{github.workspace}}/static_check.txt

--- a/.github/workflows/github-actions_basic_CI.yml
+++ b/.github/workflows/github-actions_basic_CI.yml
@@ -28,7 +28,7 @@ jobs:
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: |
-          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 /source/
+          cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ${{github.workspace}}/source/
           cmake -B ${{github.workspace}}/build
 
     - uses: actions/upload-artifact@v2


### PR DESCRIPTION
close #12 

This branch implements the use of Cpp-Checker on the code. After the CI builds the project, it is run on an Ubuntu gitlab runner and uploads an artifact named Static_Check_Output.zip containing the output in txt file.

## Platforms

Checked on Linux


TODO Windows ?